### PR TITLE
Add access to 'data' with indifferent access

### DIFF
--- a/lib/structural/model.rb
+++ b/lib/structural/model.rb
@@ -1,7 +1,5 @@
 module Structural
   module Model
-    attr_reader :data
-
     def initialize(data = {})
       @data = Hashifier.hashify(data)
     end
@@ -21,6 +19,10 @@ module Structural
 
     def hash
       data.hash
+    end
+
+    def data
+      @data.with_indifferent_access
     end
 
     private

--- a/lib/structural/version.rb
+++ b/lib/structural/version.rb
@@ -1,3 +1,3 @@
 module Structural
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/lib/structural/model_spec.rb
+++ b/spec/lib/structural/model_spec.rb
@@ -30,21 +30,21 @@ class TestModel
 end
 
 describe Structural::Model do
-  let(:model) do
-    TestModel.new(
-      :foo => 3,
-      :baz => 6,
-      :quxx => 8,
-      :nested_hash => {1 => :one, 2 => :two},
-      :test_model => {},
-      :date_of_birth => '06-06-1983',
-      :aliased_model => {'yak' => 11},
-      :nested_models => [{'yak' => 11}, {:yak => 14}],
-      :extra_nested_model => { :cats => "MIAOW" },
-      :time_stamp => '2015-01-27T13:13:13+00:00'
-    )
-  end
-
+  let(:model) { TestModel.new(data) }
+  let(:data) {
+    {
+      'foo' => 3,
+      'baz' => 6,
+      'quxx' => 8,
+      'nested_hash' => {1 => :one, 2 => :two},
+      'test_model' => {},
+      'date_of_birth' => '06-06-1983',
+      'aliased_model' => {'yak' => 11},
+      'nested_models' => [{'yak' => 11}, {'yak' => 14}],
+      'extra_nested_model' => { 'cats' => "MIAOW" },
+      'time_stamp' => '2015-01-27T13:13:13+00:00'
+    }
+  }
 
   describe ".new" do
     it 'converts any passed Structural models to their hash representations' do
@@ -164,6 +164,20 @@ describe Structural::Model do
       hash = { one => :found }
       hash[two].should be_nil
       hash[one].should eq :found
+    end
+  end
+
+  describe "#data" do
+    it 'returns the model as a hash' do
+      model.data.should eq data
+    end
+
+    it 'allows access to values via string keys' do
+      model.data['foo'].should eq 3
+    end
+
+    it 'allows access to values via symbol keys' do
+      model.data[:foo].should eq 3
     end
   end
 


### PR DESCRIPTION
Previously, Structural was changed to only allow access to keys via symbols, however there are projects using this library that access 'data' via 'string' keys. Since 'activesupport' is a dependency of this gem, we can leverage it to provide the desired behaviour.