### PR TITLE
Allow has_one association to support default option

### DIFF
--- a/lib/structural.rb
+++ b/lib/structural.rb
@@ -3,6 +3,7 @@ require 'money'
 
 require 'structural/version'
 require 'structural/missing_attribute_error'
+require 'structural/invalid_default_type_error'
 require 'structural/hashifier'
 require 'structural/model/definer'
 require 'structural/model/descriptor'

--- a/lib/structural/invalid_default_type_error.rb
+++ b/lib/structural/invalid_default_type_error.rb
@@ -1,0 +1,4 @@
+module Structural
+  class InvalidDefaultTypeError < StandardError
+  end
+end

--- a/lib/structural/model/has_one.rb
+++ b/lib/structural/model/has_one.rb
@@ -2,7 +2,7 @@ module Structural
   module Model
     class HasOne < Association
       def value_of(data)
-        child = data.fetch(key) { raise MissingAttributeError, key }
+        child = data.fetch(key, &default_value)
         type.new(child) unless child.nil?
       end
     end

--- a/lib/structural/model/has_one.rb
+++ b/lib/structural/model/has_one.rb
@@ -7,13 +7,16 @@ module Structural
       end
 
       def default
-        value = super
+        valid_type_check(super)
+      end
 
-        if value.is_a? Hash
-          value
-        else
-          raise Structural::InvalidDefaultTypeError
-        end
+      private
+
+      def valid_type_check(v)
+        case v
+        when Hash then v
+        when Proc then valid_type_check(v.call)
+        else raise Structural::InvalidDefaultTypeError end
       end
     end
   end

--- a/lib/structural/model/has_one.rb
+++ b/lib/structural/model/has_one.rb
@@ -5,6 +5,16 @@ module Structural
         child = data.fetch(key, &default_value)
         type.new(child) unless child.nil?
       end
+
+      def default
+        value = super
+
+        if value.is_a? Hash
+          value
+        else
+          raise Structural::InvalidDefaultTypeError
+        end
+      end
     end
   end
 end

--- a/lib/structural/version.rb
+++ b/lib/structural/version.rb
@@ -1,3 +1,3 @@
 module Structural
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
 end

--- a/lib/structural/version.rb
+++ b/lib/structural/version.rb
@@ -1,3 +1,3 @@
 module Structural
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/lib/structural/model_spec.rb
+++ b/spec/lib/structural/model_spec.rb
@@ -20,12 +20,20 @@ class TestModel
   has_one :aliased_model, :type => NestedModel
   has_one :nested_model, :key => 'aliased_model'
   has_one :extra_nested_model
+  has_one :nested_model_with_default, default: { name: 'Michael' }
   has_one :test_model
   has_many :nested_models
 
   class ExtraNestedModel
     include Structural::Model
     field :cats
+  end
+
+  class NestedModelWithDefault
+    include Structural::Model
+
+    field :name, default: nil
+    field :surname, default: nil
   end
 end
 
@@ -100,6 +108,10 @@ describe Structural::Model do
     end
     it "allows recursively defined models" do
       model.test_model.should be_a TestModel
+    end
+    it "allows default values" do
+      model.nested_model_with_default.name.should eq 'Michael'
+      model.nested_model_with_default.surname.should be_nil
     end
   end
 

--- a/spec/lib/structural/model_spec.rb
+++ b/spec/lib/structural/model_spec.rb
@@ -20,7 +20,9 @@ class TestModel
   has_one :aliased_model, :type => NestedModel
   has_one :nested_model, :key => 'aliased_model'
   has_one :extra_nested_model
+  has_one :nested_model_with_invalid_default_type, default: nil
   has_one :nested_model_with_default, default: { name: 'Michael' }
+  has_one :missing_nested_model_without_default
   has_one :test_model
   has_many :nested_models
 
@@ -112,6 +114,16 @@ describe Structural::Model do
     it "allows default values" do
       model.nested_model_with_default.name.should eq 'Michael'
       model.nested_model_with_default.surname.should be_nil
+    end
+    it "fails if passed a non-hash as default" do
+      expect {
+        model.nested_model_with_invalid_default_type
+      }.to raise_error(Structural::InvalidDefaultTypeError)
+    end
+    it "fails for missing associations without defaults" do
+      expect {
+        model.missing_nested_model_without_default
+      }.to raise_error(Structural::MissingAttributeError)
     end
   end
 


### PR DESCRIPTION
Currently `has_one` always raises an error if the key isn't passed
in as data. This change allows a default to be specified that will
be used when initializing the associated structural class.

One use-case for this is to allow the creation of naive structural
classes with nested associations.

```ruby
class CustomerDetails
  field :account_name, default: nil

  has_one :credentials, default: {}, type: Credentials
  has_one :billing_address, default: {}, type: BillingAddress

  def name
    account_name || credentials.name || billing_address.name
  end
end
```

In the above snippet, we know that there are three ways to pass the
customer's name: as top-level `account_name`, as `name` nested in
`credentials` or as `name` nested in `billing_address`.

Having a default allows you to specify a single access point that
attempts to access the data from the various sources.